### PR TITLE
Fix a bug regarding duplicates tree IDs when writing to database 

### DIFF
--- a/qtrees/fisbroker.py
+++ b/qtrees/fisbroker.py
@@ -1,9 +1,9 @@
+import os
 import requests
 import geopandas as gpd
 import pandas as pd
 from requests import Request
 from owslib.wfs import WebFeatureService
-import os
 from datetime import datetime
 from qtrees.helper import get_logger
 
@@ -24,14 +24,16 @@ def _prepare_tree_data(gdf, street_tree):
     gdf['updated_at'] = date
     gdf = gdf.rename(columns={"baumid": "id"})
     gdf = gdf.drop('gml_id', axis=1)
-    gdf.drop_duplicates(subset=['id'], keep='first')
+    duplicates_in_batch = set(gdf[gdf.id.duplicated()].id)
+    gdf.drop_duplicates(subset=['id'], keep='first', inplace=True)
+    return gdf, duplicates_in_batch
 
-    return gdf
 
-
-def store_trees_batchwise_to_db(trees_file, street_tree, engine, lu_ids=None, n_batch_size=100000):
+def store_trees_batchwise_to_db(trees_file, street_tree, engine, lu_ids=None,
+                                n_batch_size=100000):
     """
-    load tree file, process data, remove duplicates and stored it into a db - all batchwise
+    load tree file, process data, remove duplicates and stored it into a db -
+    all batchwise
 
     Parameters
     ----------
@@ -52,17 +54,22 @@ def store_trees_batchwise_to_db(trees_file, street_tree, engine, lu_ids=None, n_
     n_start = 0
     n_round = 0
     lu_ids = lu_ids or set()
+
     while True:
         n_end = n_start + n_batch_size
         gdf = gpd.read_file(trees_file, rows=slice(n_start, n_end))
-        n_rows = len(gdf)
+        n_gdf = len(gdf)
         # prepare data and remove patch-internal duplicates
-        gdf = _prepare_tree_data(gdf, street_tree=street_tree)
-        duplicates = lu_ids.intersection(gdf["id"])
-        n_duplicates = len(duplicates) + n_rows - len(gdf)
+        gdf, duplicates_in_batch = _prepare_tree_data(gdf,
+                                                      street_tree=street_tree)
+        duplicates_between_batches = lu_ids.intersection(gdf["id"])
+        duplicates = duplicates_between_batches | duplicates_in_batch
+        n_duplicates = len(duplicates)
         if n_duplicates > 0:
-            logger.warning("Found duplicates: %s", list(duplicates))
-        gdf = gdf[~gdf["id"].isin(duplicates)]
+            logger.warning(f"Found {n_duplicates} unique duplicates: \
+                           {list(duplicates)}")
+        gdf = gdf[~gdf["id"].isin(duplicates_between_batches)]
+
         lu_ids.update(gdf["id"])
 
         n_round += 1
@@ -70,13 +77,14 @@ def store_trees_batchwise_to_db(trees_file, street_tree, engine, lu_ids=None, n_
         n_start = n_end
 
         try:
-            gdf.to_postgis("trees", engine, if_exists="append", schema="public")
+            gdf.to_postgis("trees", engine, if_exists="append",
+                           schema="public")
         except Exception as e:
             logger.error("Cannot write to db: %s", e)
             exit(121)
 
         # running out of data
-        if len(gdf) < n_batch_size - n_duplicates:
+        if n_gdf < n_batch_size:
             break
 
     return lu_ids
@@ -91,7 +99,8 @@ def download_tree_file(dir_data, type, use_cached=True):
     dir_data: str
         cache dir
     type: str
-        defines tree dataset - currently 'wfs_baumbestand' or 'wfs_baumbestand_an'
+        defines tree dataset - currently 'wfs_baumbestand' or
+        'wfs_baumbestand_an'
     use_cached: bool
         defines if cached data is used or data should be downloaded again
 
@@ -105,8 +114,8 @@ def download_tree_file(dir_data, type, use_cached=True):
         return trees_file
 
     logger.info("Downloading '%s' data", type)
-    params = dict(service="WFS", version="2.0.0", request='GetFeature', typeNames=f"fis:s_{type}",
-                  srsName="EPSG:25833")
+    params = dict(service="WFS", version="2.0.0", request='GetFeature',
+                  typeNames=f"fis:s_{type}", srsName="EPSG:25833")
     url = f"http://fbinter.stadt-berlin.de/fb/wfs/data/senstadt/s_{type}"
 
     r = requests.get(url, params=params)
@@ -127,14 +136,16 @@ def get_trees(trees_file):
         trees_gdf = gpd.read_file(trees_file, driver='GeoJSON')
         logger.debug("Reading trees geo data frames from %s.", trees_file)
     else:
-        params = dict(service="WFS", version="2.0.0", request='GetFeature', typeNames="fis:s_wfs_baumbestand_an",
+        params = dict(service="WFS", version="2.0.0", request='GetFeature',
+                      typeNames="fis:s_wfs_baumbestand_an", 
                       srsName="EPSG:25833")
         url = "http://fbinter.stadt-berlin.de/fb/wfs/data/senstadt/s_wfs_baumbestand_an"
         q = requests.Request('GET', url, params=params).prepare().url
         trees_gdf_an = gpd.read_file(q).to_crs(4326)
         trees_gdf_an["street_tree"] = False
 
-        params = dict(service="WFS", version="2.0.0", request='GetFeature', typeNames="fis:s_wfs_baumbestand",
+        params = dict(service="WFS", version="2.0.0", request='GetFeature',
+                      typeNames="fis:s_wfs_baumbestand",
                       srsName="EPSG:25833")
         url = "http://fbinter.stadt-berlin.de/fb/wfs/data/senstadt/s_wfs_baumbestand"
         q = requests.Request('GET', url, params=params).prepare().url
@@ -166,7 +177,8 @@ def get_gdf(url, crs, geojson_file):
         logger.debug("Gdf doesn't exist, making a wfs request.")
         wfs = WebFeatureService(url=url)
         layer = list(wfs.contents)[-1]
-        params = dict(service="wfs", version="2.0.0", request='GetFeature', TYPENAMES=layer, crs=crs)
+        params = dict(service="wfs", version="2.0.0", request='GetFeature',
+                      TYPENAMES=layer, crs=crs)
         q = Request('GET', url, params=params).prepare().url
         gdf = gpd.read_file(q).set_crs(epsg=25833)
         gdf = gdf.to_crs(4326)

--- a/scripts/script_store_trees_in_db.py
+++ b/scripts/script_store_trees_in_db.py
@@ -2,12 +2,14 @@
 """
 Download tree data and store into db.
 Usage:
-  script_store_trees_in_db.py [--data_directory=DATA_DIRECTORY] [--db_qtrees=DB_QTREES] [--batch_size=BATCH_SIZE]
+  script_store_trees_in_db.py [--data_directory=DATA_DIRECTORY]
+    [--db_qtrees=DB_QTREES] [--batch_size=BATCH_SIZE]
   script_store_trees_in_db.py (-h | --help)
 Options:
-  --data_directory=DATA_DIRECTORY              Directory for data [default: data/trees]
-  --db_qtrees=DB_QTREES                        Database name [default:]
-  --batch_size=BATCH_SiZE                      Batch size [default: 100000]
+  --data_directory=DATA_DIRECTORY       Directory for data
+    [default: data/trees]
+  --db_qtrees=DB_QTREES                 Database name [default:]
+  --batch_size=BATCH_SiZE               Batch size [default: 100000]
 """
 
 import sys
@@ -24,9 +26,11 @@ logger = get_logger(__name__, log_level="INFO")
 def main():
     logger.info("Args: %s", sys.argv[1:])
     # Parse arguments
-    args = docopt(__doc__)
+    args = docopt(__doc__) 
     logger.debug("Init db args")
-    db_qtrees, postgres_passwd = init_db_args(db=args["--db_qtrees"], db_type="qtrees", logger=logger)
+    db_qtrees, postgres_passwd = init_db_args(db=args["--db_qtrees"],
+                                              db_type="qtrees",
+                                              logger=logger)
 
     data_directory = args["--data_directory"]
     n_batch_size = int(args["--batch_size"])
@@ -46,8 +50,9 @@ def main():
             return
 
     logger.debug("Do update")
-    if not os.path.exists(os.path.dirname(data_directory)):
-        os.makedirs(os.path.dirname(data_directory))
+
+    if not os.path.exists(data_directory):
+        os.makedirs(data_directory)
 
     # download tree files in case of need
     filename_street_trees = download_tree_file(

--- a/scripts/script_store_trees_in_db.py
+++ b/scripts/script_store_trees_in_db.py
@@ -2,14 +2,12 @@
 """
 Download tree data and store into db.
 Usage:
-  script_store_trees_in_db.py [--data_directory=DATA_DIRECTORY]
-    [--db_qtrees=DB_QTREES] [--batch_size=BATCH_SIZE]
+  script_store_trees_in_db.py [--data_directory=DATA_DIRECTORY] [--db_qtrees=DB_QTREES] [--batch_size=BATCH_SIZE]
   script_store_trees_in_db.py (-h | --help)
 Options:
-  --data_directory=DATA_DIRECTORY       Directory for data
-    [default: data/trees]
-  --db_qtrees=DB_QTREES                 Database name [default:]
-  --batch_size=BATCH_SiZE               Batch size [default: 100000]
+  --data_directory=DATA_DIRECTORY              Directory for data [default: data/trees]
+  --db_qtrees=DB_QTREES                        Database name [default:]
+  --batch_size=BATCH_SiZE                      Batch size [default: 100000]
 """
 
 import sys
@@ -26,11 +24,9 @@ logger = get_logger(__name__, log_level="INFO")
 def main():
     logger.info("Args: %s", sys.argv[1:])
     # Parse arguments
-    args = docopt(__doc__) 
+    args = docopt(__doc__)
     logger.debug("Init db args")
-    db_qtrees, postgres_passwd = init_db_args(db=args["--db_qtrees"],
-                                              db_type="qtrees",
-                                              logger=logger)
+    db_qtrees, postgres_passwd = init_db_args(db=args["--db_qtrees"], db_type="qtrees", logger=logger)
 
     data_directory = args["--data_directory"]
     n_batch_size = int(args["--batch_size"])
@@ -50,7 +46,6 @@ def main():
             return
 
     logger.debug("Do update")
-
     if not os.path.exists(data_directory):
         os.makedirs(data_directory)
 


### PR DESCRIPTION
I had issues writing to database because of duplicate IDs. 

Following updated: 

- Dropping duplicate in dataframe with inplace=TRUE 
- Saving and printing all unique tree IDs that are duplicates and are removed (within one batch and between batches)
- Make the repository for the raw tree .xml files be created at the right path 

Changed some pep8 formatting. 
