### PR TITLE
Fix/db dump restore

### DIFF
--- a/scripts/script_restore_db_data.sh
+++ b/scripts/script_restore_db_data.sh
@@ -16,11 +16,12 @@ if [ -n "$QTREES_VERSION" ]; then
     filename=$(ls -t $data_dir/*.dump | head -1)
     # dump data before truncating
     filename_safe="$data_dir/safe.dump"
+    echo "safe dump"
     PGPASSWORD=${POSTGRES_PASSWD} pg_dump --host $DB_QTREES --port 5432 --username postgres --format custom --file filename_safe -n public -n private --exclude-table public.spatial_ref_sys --data-only qtrees
     echo "Truncating data in DB"
     PGPASSWORD=${POSTGRES_PASSWD} psql --host $DB_QTREES -U postgres -d qtrees -c "SELECT * from private.truncate_tables()"
     echo "Loading data into DB from \"$filename\""
-    PGPASSWORD=${POSTGRES_PASSWD} pg_restore --host $DB_QTREES --port 5432 --username postgres $filename --data-only --dbname=qtrees
+    PGPASSWORD=${POSTGRES_PASSWD} pg_restore --host $DB_QTREES --port 5432 --username postgres --dbname=qtrees --clean --verbose < $filename
   fi
 else
   echo "Error: Variable QTREES_VERSION is not set"

--- a/scripts/script_restore_db_data.sh
+++ b/scripts/script_restore_db_data.sh
@@ -21,7 +21,7 @@ if [ -n "$QTREES_VERSION" ]; then
     echo "Truncating data in DB"
     PGPASSWORD=${POSTGRES_PASSWD} psql --host $DB_QTREES -U postgres -d qtrees -c "SELECT * from private.truncate_tables()"
     echo "Loading data into DB from \"$filename\""
-    PGPASSWORD=${POSTGRES_PASSWD} pg_restore --host $DB_QTREES --port 5432 --username postgres --dbname=qtrees --clean --verbose < $filename
+    PGPASSWORD=${POSTGRES_PASSWD} pg_restore --host $DB_QTREES --port 5432 --username postgres --dbname=qtrees --clean < $filename
   fi
 else
   echo "Error: Variable QTREES_VERSION is not set"


### PR DESCRIPTION
Add flag --clean when restoring the database dumps. This flag drops everything and recreates everything. 
With the --verbose flag on, we have: 

<img width="605" alt="Screenshot 2023-09-29 at 10 34 57" src="https://github.com/technologiestiftung/qtrees-ai-data/assets/125886907/ba14622a-86c1-4f7f-8e76-08185017601c">
<img width="340" alt="Screenshot 2023-09-29 at 10 35 28" src="https://github.com/technologiestiftung/qtrees-ai-data/assets/125886907/47b4a8b3-a627-4662-bc5e-14025c8826f9">
<img width="445" alt="Screenshot 2023-09-29 at 10 36 19" src="https://github.com/technologiestiftung/qtrees-ai-data/assets/125886907/5d274883-7036-4a6e-820e-6563ef7bce07">
<img width="450" alt="Screenshot 2023-09-29 at 10 36 32" src="https://github.com/technologiestiftung/qtrees-ai-data/assets/125886907/aa476e88-03ae-4da9-988e-872b084581ad">
